### PR TITLE
Remove unneeded condition from myReceive to avoid message loss.

### DIFF
--- a/modules/libcom/src/osi/os/default/osdMessageQueue.cpp
+++ b/modules/libcom/src/osi/os/default/osdMessageQueue.cpp
@@ -352,8 +352,7 @@ myReceive(epicsMessageQueueId pmsg, void *message, unsigned int size,
 
     epicsMutexUnlock(pmsg->mutex);
 
-    if (threadNode.eventSent && (threadNode.size <= size) &&
-        status == epicsEventOK)
+    if (threadNode.eventSent && (threadNode.size <= size))
         return threadNode.size;
     return -1;
 }


### PR DESCRIPTION
If we timeout while a send is happening, a message will be put into threadNode by the sender but we will ignore it because status is epicsEventWaitTimeout, not epicsEventOK.  The status check is unneeded and causes us to lose a message.