### PR TITLE
Enable LinuxRT and RTEMS cross compilation from rhel7, 8, 9 (R7.0.3.1-1.0)

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -122,7 +122,7 @@ INSTALL_CMD = $(INSTALL_LOCATION)/db
 #  Definitions in configure/os/CONFIG_SITE.<host>.Common
 #  may override this setting.
 CROSS_COMPILER_TARGET_ARCHS=
-ifeq ($(filter $(EPICS_HOST_ARCH),rhel6-x86_64 rhel7-x86_64),$(EPICS_HOST_ARCH))
+ifeq ($(filter $(EPICS_HOST_ARCH),rhel6-x86_64 rhel7-x86_64 rhel8-x86_64 rhel9-x86_64),$(EPICS_HOST_ARCH))
 CROSS_COMPILER_TARGET_ARCHS += linuxRT-x86_64 linuxRT-i686 linuxRT-arm_zynq
 CROSS_COMPILER_TARGET_ARCHS += RTEMS-beatnik RTEMS-mvme3100 RTEMS-uC5282 RTEMS-svgm
 endif

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -122,12 +122,9 @@ INSTALL_CMD = $(INSTALL_LOCATION)/db
 #  Definitions in configure/os/CONFIG_SITE.<host>.Common
 #  may override this setting.
 CROSS_COMPILER_TARGET_ARCHS=
-ifeq '$(EPICS_HOST_ARCH)' 'rhel6-x86_64'
+ifeq ($(filter $(EPICS_HOST_ARCH),rhel6-x86_64 rhel7-x86_64),$(EPICS_HOST_ARCH))
 CROSS_COMPILER_TARGET_ARCHS += linuxRT-x86_64 linuxRT-i686 linuxRT-arm_zynq
 CROSS_COMPILER_TARGET_ARCHS += RTEMS-beatnik RTEMS-mvme3100 RTEMS-uC5282 RTEMS-svgm
-endif
-ifeq '$(EPICS_HOST_ARCH)' 'rhel7-x86_64'
-CROSS_COMPILER_TARGET_ARCHS += linuxRT-x86_64
 endif
 
 # If only some of your host architectures can compile the


### PR DESCRIPTION
The buildroot and RTEMS toolchains we use on the accelerator side work just fine with newer versions of RHEL.

My understanding is that this change is not possible for PCDS's version of base, due to their RTEMS toolchain being broken currently.

Addresses half of #12 