### PR TITLE
Add SLAC_PACKAGE_TOP to allow changing of package directories

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -148,6 +148,10 @@ CROSS_COMPILER_RUNTEST_ARCHS=
 #    SHARED_LIBRARIES = NO  and STATIC_BUILD = YES
 SHARED_LIBRARIES=YES
 
+# Defines the TOP location of packages required by SLAC's EPICS.
+# Defaults to old location on AFS, override this in CONFIG_SITE.local
+SLAC_PACKAGE_TOP=/afs/slac/package
+
 # Build client objects statically.
 #  Must be either YES or NO.
 STATIC_BUILD=YES

--- a/configure/os/CONFIG.Common.RTEMS
+++ b/configure/os/CONFIG.Common.RTEMS
@@ -30,7 +30,7 @@
 -include $(CONFIG)/os/CONFIG_SITE.Common.RTEMS
 
 ifeq ($(T_A),RTEMS-mvme5500)
-RTEMS_SITE_TOP=/afs/slac/package/rtems/4.6.2/
+RTEMS_SITE_TOP=$(SLAC_PACKAGE_TOP)/rtems/4.6.2/
 RTEMS_BASE=$(RTEMS_SITE_TOP)/host/i386_linux2x/
 else
 #RTEMS_MAKEFILE_PATH=/afs/slac/package/rtems/4.7/target/ssrlApps/config
@@ -49,7 +49,7 @@ else
 # since checkRelease is pretty dumb...
 #
 #RTEMS_SITE_TOP=/afs/slac/package/rtems/4.9.4/
-RTEMS_SITE_TOP=/afs/slac/package/rtems/4.10.2/
+RTEMS_SITE_TOP=$(SLAC_PACKAGE_TOP)/rtems/4.10.2/
 RTEMS_BASE=$(RTEMS_SITE_TOP)/host/amd64_linux26/
 
 #RTEMS_PATCHLVL=rtems_p0

--- a/configure/os/CONFIG_SITE.Common.linuxRT-arm_zynq
+++ b/configure/os/CONFIG_SITE.Common.linuxRT-arm_zynq
@@ -1,6 +1,6 @@
 # Location of linuxRT GNU ToolChain
 #LINUX_RT_HOME=/nfs/slac/g/lcls/build/linuxRT
-LINUX_RT_HOME=/afs/slac/package/linuxRT
+LINUX_RT_HOME=$(SLAC_PACKAGE_TOP)/linuxRT
 #LINUX_RT_HOME=/afs/slac/g/lcls/package/linuxRT
 
 #LINUXRT_BUILDROOT_VERSION=buildroot-2015.02
@@ -35,7 +35,7 @@ COMMANDLINE_LIBRARY = READLINE
 # =========================================================================
 # Valgrind support
 # =========================================================================
-VALGRIND_TOP=/afs/slac/g/lcls/package/valgrind/3.10.1
+VALGRIND_TOP=$(SLAC_PACKAGE_TOP)/valgrind/3.10.1
 VALGRIND_T_A=$(VALGRIND_TOP)/$(T_A)
 ifneq ($(wildcard $(VALGRIND_T_A)),)
 VALGRIND_INCLUDE=$(VALGRIND_T_A)/include

--- a/configure/os/CONFIG_SITE.Common.linuxRT-i686
+++ b/configure/os/CONFIG_SITE.Common.linuxRT-i686
@@ -1,6 +1,6 @@
 # Location of linuxRT GNU ToolChain
 #LINUX_RT_HOME=/nfs/slac/g/lcls/build/linuxRT
-LINUX_RT_HOME=/afs/slac/package/linuxRT
+LINUX_RT_HOME=$(SLAC_PACKAGE_TOP)/linuxRT
 #LINUX_RT_HOME=/afs/slac/g/lcls/package/linuxRT
 
 #LINUXRT_BUILDROOT_VERSION=buildroot-2015.02
@@ -35,7 +35,7 @@ COMMANDLINE_LIBRARY = READLINE
 # =========================================================================
 # Valgrind support
 # =========================================================================
-VALGRIND_TOP=/afs/slac/g/lcls/package/valgrind/3.10.1
+VALGRIND_TOP=$(SLAC_PACKAGE_TOP)/valgrind/3.10.1
 VALGRIND_T_A=$(VALGRIND_TOP)/$(T_A)
 ifneq ($(wildcard $(VALGRIND_T_A)),)
 VALGRIND_INCLUDE=$(VALGRIND_T_A)/include

--- a/configure/os/CONFIG_SITE.Common.linuxRT-x86_64
+++ b/configure/os/CONFIG_SITE.Common.linuxRT-x86_64
@@ -1,6 +1,6 @@
 # Location of linuxRT GNU ToolChain
 #LINUX_RT_HOME=/nfs/slac/g/lcls/build/linuxRT
-LINUX_RT_HOME=/afs/slac/package/linuxRT
+LINUX_RT_HOME=$(SLAC_PACKAGE_TOP)/linuxRT
 #LINUX_RT_HOME=/afs/slac/g/lcls/package/linuxRT
 
 #LINUXRT_BUILDROOT_VERSION=buildroot-2015.02
@@ -35,7 +35,7 @@ COMMANDLINE_LIBRARY = READLINE
 # =========================================================================
 # Valgrind support
 # =========================================================================
-VALGRIND_TOP=/afs/slac/g/lcls/package/valgrind/3.10.1
+VALGRIND_TOP=$(SLAC_PACKAGE_TOP)/valgrind/3.10.1
 VALGRIND_T_A=$(VALGRIND_TOP)/$(T_A)
 ifneq ($(wildcard $(VALGRIND_T_A)),)
 VALGRIND_INCLUDE=$(VALGRIND_T_A)/include


### PR DESCRIPTION
This can be overridden in CONFIG_SITE.local

The primary motivation here is our WIP deployment of EPICS on S3DF. On S3DF we have `/sdf/sw/epics/package`, on AFS we have `/afs/slac/package` and we only want one version of EPICS shared between the two.

I could use an environment variable here too, (i.e. `SLAC_PACKAGE_TOP` that would only be defined in the new S3DF env), but @ernestow and I feel that over-reliance on environment variables for this type of configuration is a potential footgun.

I think once AFS goes away, we can change the default to be /sdf/sw/epics/package in CONFIG_SITE and check that into git. I intentionally left it as /afs/slac/package to reduce the likelihood that someone's workflow breaks.

Open to suggestions for better ways to handle this!