### PR TITLE
Increase RTEMS patch level to rtems_p4/ssrlApps_p3

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -188,7 +188,7 @@ USE_POSIX_THREAD_PRIORITY_SCHEDULING = YES
 
 # Site version number, if set will append '-' and this string to the
 #  EPICS version number string that is reported by many tools.
-EPICS_SITE_VERSION = 1.0.8
+EPICS_SITE_VERSION = 1.0.9
 
 # For GNU compiler, use pipes rather than temporary files for
 #  communication between the various stages of compilation.

--- a/configure/os/CONFIG.Common.RTEMS
+++ b/configure/os/CONFIG.Common.RTEMS
@@ -54,11 +54,13 @@ RTEMS_BASE=$(RTEMS_SITE_TOP)/host/amd64_linux26/
 
 #RTEMS_PATCHLVL=rtems_p0
 #RTEMS_PATCHLVL=rtems_p1
-RTEMS_PATCHLVL=rtems_p3
+#RTEMS_PATCHLVL=rtems_p3
+RTEMS_PATCHLVL=rtems_p4
 
 #SSRLAPPS_PATCHLVL=ssrlApps_p1
 #SSRLAPPS_PATCHLVL=ssrlApps_p3
-SSRLAPPS_PATCHLVL=ssrlApps_p2
+#SSRLAPPS_PATCHLVL=ssrlApps_p2
+SSRLAPPS_PATCHLVL=ssrlApps_p3
 endif
 
 #--------------------------------------------------


### PR DESCRIPTION
This corresponds to the new RTEMS release, although increasing it is technically optional.